### PR TITLE
Fix container name

### DIFF
--- a/docker-container/spec/localhost/sample_spec.rb
+++ b/docker-container/spec/localhost/sample_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 set :backend, :docker
 
-set_property name: 'handmade'
+set_property name: 'amazon'
 
 describe 'container' do
   before(:all) do


### PR DESCRIPTION
コンテナ名が間違ってた。手順の方に合わせる

```
# コンテナ新規作成・起動
docker run --name amazon -it amazonlinux:2018.03 # default の bash で起動する
```